### PR TITLE
#7 Wrapped rtk-queries in `retry` utility and set `maxRetries` limit to 3

### DIFF
--- a/client/src/services/GameService.ts
+++ b/client/src/services/GameService.ts
@@ -1,4 +1,8 @@
-import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/dist/query/react';
+import {
+    createApi,
+    fetchBaseQuery,
+    retry,
+} from '@reduxjs/toolkit/dist/query/react';
 import { TGame } from '../types/TGame';
 import { API_URL } from '../config/const';
 import { TFetchGamesParams } from '../types/TFetchGamesParams';
@@ -9,11 +13,13 @@ type TNoResults = {
     status_message: string;
 };
 
+const staggeredBaseQuery = retry(fetchBaseQuery({ baseUrl: API_URL }), {
+    maxRetries: 3,
+});
+
 export const gameAPI = createApi({
     reducerPath: 'gameAPI',
-    baseQuery: fetchBaseQuery({
-        baseUrl: API_URL,
-    }),
+    baseQuery: staggeredBaseQuery,
     endpoints: (build) => ({
         fetchGames: build.query<TGame[] | TNoResults, TFetchGamesParams>({
             query: (params: TFetchGamesParams) => ({


### PR DESCRIPTION
У RTK Query есть утилита `retry`, которая будет пытаться (по дефолту) 5 раз отправить запрос, если не удалось получить данные. В неё можно передать ограничение на количество подобных повторных попыток (по тз - 3).

По итогу, если попытаться загрузить детали игры с несуществующим id, то сначала мы видим один неудачный запрос, а затем ещё 3 неудачные повторные попытки

![image](https://github.com/alyona-korenkovich/FreePlayHub/assets/54909446/6d95add0-3506-4f1f-8090-1a39675c225b)
